### PR TITLE
Remove warnings and fix types.

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -99,7 +99,7 @@ Darken a video frame-by-frame:
 """
 
 __docformat__ = 'google'
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 __version_info__ = tuple(int(num) for num in __version__.split('.'))
 
 import base64
@@ -109,19 +109,17 @@ import functools
 import importlib
 import io
 import itertools
-import math
 import numbers
 import os
 import pathlib
 import re
 import shlex
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
 import typing
-from typing import Any, Callable, ContextManager, Generator, Iterable
+from typing import Any, Callable, ContextManager, Iterable
 from typing import Iterator, List, Mapping, Optional, Sequence
 from typing import Tuple, Type, TypeVar, Union
 import urllib.request
@@ -129,8 +127,20 @@ import urllib.request
 import IPython.display
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import PIL.Image
 import PIL.ImageOps
+
+if not hasattr(PIL.Image, 'Resampling'):  # Allow Pillow<9.0.
+  PIL.Image.Resampling = PIL.Image
+
+_NDArray = npt.NDArray[Any]
+_ArrayLike = npt.ArrayLike
+_DTypeLike = npt.DTypeLike
+if typing.TYPE_CHECKING:
+  _DType = np.dtype[Any]
+else:
+  _DType = Any
 
 _IPYTHON_HTML_SIZE_LIMIT = 20_000_000
 _T = TypeVar('_T')
@@ -141,7 +151,7 @@ if typing.TYPE_CHECKING:
 else:
   _Path = Union[str, os.PathLike]
 
-## Miscellaneous.
+# ** Miscellaneous.
 
 
 class _Config:
@@ -152,7 +162,7 @@ class _Config:
 _config = _Config()
 
 
-def _open(path: _Path, *args: Any, **kwargs: Any) -> ContextManager[Any]:
+def _open(path: _Path, *args: Any, **kwargs: Any) -> Any:
   """Opens the file; this is a hook for the built-in `open()`."""
   return open(path, *args, **kwargs)
 
@@ -167,7 +177,7 @@ def _search_for_ffmpeg_path() -> Optional[str]:
   """Returns a path to the ffmpeg program, or None if not found."""
   filename = shutil.which(_config.ffmpeg_name_or_path)
   if filename:
-    return filename
+    return str(filename)
   return None
 
 
@@ -258,7 +268,7 @@ def set_output_height(num_pixels: int) -> None:
     # We want to fail gracefully for non-Colab IPython notebooks.
     output = importlib.import_module('google.colab.output')
     s = f'google.colab.output.setIframeHeight("{num_pixels}px")'
-    output.eval_js(s)  # type: ignore
+    output.eval_js(s)
   except (ModuleNotFoundError, AttributeError):
     pass
 
@@ -270,15 +280,15 @@ def set_max_output_height(num_pixels: int) -> None:
     output = importlib.import_module('google.colab.output')
     s = ('google.colab.output.setIframeHeight('
          f'0, true, {{maxHeight: {num_pixels}}})')
-    output.eval_js(s)  # type: ignore
+    output.eval_js(s)
   except (ModuleNotFoundError, AttributeError):
     pass
 
 
-## Type conversions.
+# ** Type conversions.
 
 
-def _as_valid_media_type(dtype: Any) -> Any:
+def _as_valid_media_type(dtype: _DTypeLike) -> _DType:
   """Returns validated media data type."""
   dtype = np.dtype(dtype)
   if not issubclass(dtype.type, (np.unsignedinteger, np.floating)):
@@ -287,7 +297,7 @@ def _as_valid_media_type(dtype: Any) -> Any:
   return dtype
 
 
-def _as_valid_media_array(x: Iterable[Any]) -> np.ndarray:
+def _as_valid_media_array(x: _ArrayLike) -> _NDArray:
   """Converts to ndarray (if not already), and checks validity of data type."""
   a = np.asarray(x)
   if a.dtype == bool:
@@ -296,7 +306,7 @@ def _as_valid_media_array(x: Iterable[Any]) -> np.ndarray:
   return a
 
 
-def to_type(a: Any, dtype: Any) -> np.ndarray:
+def to_type(array: _ArrayLike, dtype: _DTypeLike) -> _NDArray:
   """Returns media array converted to specified type.
 
   A "media array" is one in which the dtype is either a floating-point type
@@ -316,8 +326,9 @@ def to_type(a: Any, dtype: Any) -> np.ndarray:
   Returns:
     Array `a` if it is already of the specified dtype, else a converted array.
   """
-  a = np.asarray(a)
-  dtype = _as_valid_media_type(dtype)
+  a = np.asarray(array)
+  dtype = np.dtype(dtype)
+  del array
   if a.dtype != bool:
     _as_valid_media_type(a.dtype)  # Verify that 'a' has a valid dtype.
   if a.dtype == bool:
@@ -328,13 +339,14 @@ def to_type(a: Any, dtype: Any) -> np.ndarray:
     result = a
   elif np.issubdtype(dtype, np.unsignedinteger):
     if np.issubdtype(a.dtype, np.unsignedinteger):
-      src_max = np.iinfo(a.dtype).max
+      src_max: float = np.iinfo(a.dtype).max
     else:
       a = np.clip(a, 0.0, 1.0)
       src_max = 1.0
     dst_max = np.iinfo(dtype).max
     if dst_max <= np.iinfo(np.uint16).max:
-      result = (a * np.float32(dst_max / src_max) + 0.5).astype(dtype)
+      scale = np.array(dst_max / src_max, dtype=np.float32)
+      result = (a * scale + 0.5).astype(dtype)
     elif dst_max <= np.iinfo(np.uint32).max:
       result = (a.astype(np.float64) * (dst_max / src_max) + 0.5).astype(dtype)
     else:
@@ -353,7 +365,7 @@ def to_type(a: Any, dtype: Any) -> np.ndarray:
   return result
 
 
-def to_float01(a: Any, dtype: Any = np.float32) -> np.ndarray:
+def to_float01(a: _ArrayLike, dtype: _DTypeLike = np.float32) -> _NDArray:
   """If array has unsigned integers, rescales them to the range [0.0, 1.0].
 
   Scaling is such that uint(0) maps to 0.0 and uint(MAX) maps to 1.0.  See
@@ -367,25 +379,25 @@ def to_float01(a: Any, dtype: Any = np.float32) -> np.ndarray:
     A new array of dtype values in the range [0.0, 1.0] if the input array `a`
     contains unsigned integers; otherwise, array `a` is returned unchanged.
   """
+  a = np.asarray(a)
   dtype = np.dtype(dtype)
   if not np.issubdtype(dtype, np.floating):
     raise ValueError(f'Type {dtype} is not floating-point.')
-  a = np.asarray(a)
   if np.issubdtype(a.dtype, np.floating):
     return a
   return to_type(a, dtype)
 
 
-def to_uint8(a: Any) -> np.ndarray:
+def to_uint8(a: _ArrayLike) -> _NDArray:
   """Returns array converted to uint8 values; see `to_type`."""
   return to_type(a, np.uint8)
 
 
-## Functions to generate example image and video data.
+# ** Functions to generate example image and video data.
 
 
 def color_ramp(shape: Tuple[int, int] = (64, 64), *,
-               dtype: Any = np.float32) -> np.ndarray:
+               dtype: _DTypeLike = np.float32) -> _NDArray:
   """Returns an image of a red-green color gradient.
 
   This is useful for quick experimentation and testing.  See also
@@ -405,7 +417,7 @@ def color_ramp(shape: Tuple[int, int] = (64, 64), *,
 def moving_circle(shape: Tuple[int, int] = (256, 256),
                   num_images: int = 10,
                   *,
-                  dtype: Any = np.float32) -> np.ndarray:
+                  dtype: _DTypeLike = np.float32) -> _NDArray:
   """Returns a video of a circle moving in front of a color ramp.
 
   This is useful for quick experimentation and testing.  See also `color_ramp`
@@ -421,7 +433,7 @@ def moving_circle(shape: Tuple[int, int] = (256, 256),
   _check_2d_shape(shape)
   dtype = np.dtype(dtype)
 
-  def generate_image(image_index: int) -> np.ndarray:
+  def generate_image(image_index: int) -> _NDArray:
     """Returns a video frame image."""
     image = color_ramp(shape, dtype=dtype)
     yx = np.moveaxis(np.indices(shape), 0, -1)
@@ -437,7 +449,7 @@ def moving_circle(shape: Tuple[int, int] = (256, 256),
   return np.array([generate_image(i) for i in range(num_images)])
 
 
-## Color-space conversions.
+# ** Color-space conversions.
 
 # Same matrix values as in two sources:
 # https://github.com/scikit-image/scikit-image/blob/master/skimage/color/colorconv.py#L377
@@ -450,7 +462,7 @@ _RGB_FROM_YUV_MATRIX = np.linalg.inv(_YUV_FROM_RGB_MATRIX)
 _YUV_CHROMA_OFFSET = np.array([0.0, 0.5, 0.5], dtype=np.float32)
 
 
-def yuv_from_rgb(rgb: Any) -> np.ndarray:
+def yuv_from_rgb(rgb: _ArrayLike) -> _NDArray:
   """Returns the RGB image/video mapped to YUV [0,1] color space.
 
   Note that the "YUV" color space used by video compressors is actually YCbCr!
@@ -461,15 +473,15 @@ def yuv_from_rgb(rgb: Any) -> np.ndarray:
   rgb = to_float01(rgb)
   if rgb.shape[-1] != 3:
     raise ValueError(f'The last dimension in {rgb.shape} is not 3.')
-  return np.matmul(rgb, _YUV_FROM_RGB_MATRIX) + _YUV_CHROMA_OFFSET
+  return rgb @ _YUV_FROM_RGB_MATRIX + _YUV_CHROMA_OFFSET
 
 
-def rgb_from_yuv(yuv: Any) -> np.ndarray:
+def rgb_from_yuv(yuv: _ArrayLike) -> _NDArray:
   """Returns the YUV image/video mapped to RGB [0,1] color space."""
   yuv = to_float01(yuv)
   if yuv.shape[-1] != 3:
     raise ValueError(f'The last dimension in {yuv.shape} is not 3.')
-  return np.matmul(yuv - _YUV_CHROMA_OFFSET, _RGB_FROM_YUV_MATRIX)
+  return (yuv - _YUV_CHROMA_OFFSET) @ _RGB_FROM_YUV_MATRIX
 
 
 # Same matrix values as in
@@ -487,7 +499,7 @@ _YCBCR_OFFSET = np.array([16.0, 128.0, 128.0], dtype=np.float32)
 # "studio range of 16-240 for U and V".  (Where does value 182 come from?)
 
 
-def ycbcr_from_rgb(rgb: Any) -> np.ndarray:
+def ycbcr_from_rgb(rgb: _ArrayLike) -> _NDArray:
   """Returns the RGB image/video mapped to YCbCr [0,1] color space.
 
   The YCbCr color space is the one called "YUV" by video compressors.
@@ -498,21 +510,22 @@ def ycbcr_from_rgb(rgb: Any) -> np.ndarray:
   rgb = to_float01(rgb)
   if rgb.shape[-1] != 3:
     raise ValueError(f'The last dimension in {rgb.shape} is not 3.')
-  return (np.matmul(rgb, _YCBCR_FROM_RGB_MATRIX) + _YCBCR_OFFSET) / 255.0
+  return (rgb @ _YCBCR_FROM_RGB_MATRIX + _YCBCR_OFFSET) / 255.0
 
 
-def rgb_from_ycbcr(ycbcr: Any) -> np.ndarray:
+def rgb_from_ycbcr(ycbcr: _ArrayLike) -> _NDArray:
   """Returns the YCbCr image/video mapped to RGB [0,1] color space."""
   ycbcr = to_float01(ycbcr)
   if ycbcr.shape[-1] != 3:
     raise ValueError(f'The last dimension in {ycbcr.shape} is not 3.')
-  return np.matmul(ycbcr * 255.0 - _YCBCR_OFFSET, _RGB_FROM_YCBCR_MATRIX)
+  return (ycbcr * 255.0 - _YCBCR_OFFSET) @ _RGB_FROM_YCBCR_MATRIX
 
 
-## Image processing.
+# ** Image processing.
 
 
-def _pil_image(image: Any, mode: Optional[str] = None) -> PIL.Image.Image:
+def _pil_image(image: _ArrayLike,
+               mode: Optional[str] = None) -> PIL.Image.Image:
   """Returns a PIL image given a numpy matrix (either uint8 or float [0,1])."""
   image = _as_valid_media_array(image)
   if image.ndim not in (2, 3):
@@ -520,7 +533,7 @@ def _pil_image(image: Any, mode: Optional[str] = None) -> PIL.Image.Image:
   return PIL.Image.fromarray(image, mode=mode)
 
 
-def resize_image(image: Any, shape: Tuple[int, int]) -> np.ndarray:
+def resize_image(image: _ArrayLike, shape: Tuple[int, int]) -> _NDArray:
   """Resizes image to specified spatial dimensions using a Lanczos filter.
 
   Args:
@@ -543,7 +556,8 @@ def resize_image(image: Any, shape: Tuple[int, int]) -> np.ndarray:
       image.dtype == np.uint8 and image.ndim == 3 and image.shape[2] in (3, 4))
   if supported_single_channel or supported_multichannel:
     return np.array(
-        _pil_image(image).resize(shape[::-1], resample=PIL.Image.LANCZOS),
+        _pil_image(image).resize(shape[::-1],
+                                 resample=PIL.Image.Resampling.LANCZOS),
         dtype=image.dtype)
   if image.ndim == 2:
     # We convert to floating-poing for resizing and convert back.
@@ -553,11 +567,11 @@ def resize_image(image: Any, shape: Tuple[int, int]) -> np.ndarray:
       [resize_image(channel, shape) for channel in np.moveaxis(image, -1, 0)])
 
 
-## Video processing.
+# ** Video processing.
 
 
-def resize_video(video: Iterable[np.ndarray], shape: Tuple[int,
-                                                           int]) -> np.ndarray:
+def resize_video(video: Iterable[_NDArray], shape: Tuple[int,
+                                                         int]) -> _NDArray:
   """Resizes `video` to specified spatial dimensions using a Lanczos filter.
 
   Args:
@@ -571,7 +585,7 @@ def resize_video(video: Iterable[np.ndarray], shape: Tuple[int,
   return np.array([resize_image(image, shape) for image in video])
 
 
-## General I/O.
+# ** General I/O.
 
 
 def _is_url(path_or_url: _Path) -> bool:
@@ -593,7 +607,7 @@ def read_contents(path_or_url: _Path) -> bytes:
 
 
 @contextlib.contextmanager
-def _read_via_local_file(path_or_url: _Path) -> Generator[str, None, None]:
+def _read_via_local_file(path_or_url: _Path) -> Iterator[str]:
   """Context to copy a remote file locally to read from it.
 
   Args:
@@ -613,7 +627,7 @@ def _read_via_local_file(path_or_url: _Path) -> Generator[str, None, None]:
 
 
 @contextlib.contextmanager
-def _write_via_local_file(path: _Path) -> Generator[str, None, None]:
+def _write_via_local_file(path: _Path) -> Iterator[str]:
   """Context to write a temporary local file and subsequently copy it remotely.
 
   Args:
@@ -643,13 +657,13 @@ class set_show_save_dir:  # pylint: disable=invalid-name
   It can be used either to set the state or as a context manager:
 
   >>> set_show_save_dir('/tmp')
-  >>> show_image(image, title='image1')  # Creates /tmp/image1.png.
-  >>> show_video(video, title='video2')  # Creates /tmp/video2.mp4.
+  >>> show_image(color_ramp(), title='image1')  # Creates /tmp/image1.png.
+  >>> show_video(moving_circle(), title='video2')  # Creates /tmp/video2.mp4.
   >>> set_show_save_dir(None)
 
   >>> with set_show_save_dir('/tmp'):
-  ...   show_image(image, title='image1')  # Creates /tmp/image1.png.
-  ...   show_video(video, title='video2')  # Creates /tmp/video2.mp4.
+  ...   show_image(color_ramp(), title='image1')  # Creates /tmp/image1.png.
+  ...   show_video(moving_circle(), title='video2')  # Creates /tmp/video2.mp4.
   """
 
   def __init__(self, directory: Optional[_Path]):
@@ -663,10 +677,10 @@ class set_show_save_dir:  # pylint: disable=invalid-name
     _config.show_save_dir = self._old_show_save_dir
 
 
-## Image I/O.
+# ** Image I/O.
 
 
-def read_image(path_or_url: _Path, *, dtype: Any = None) -> np.ndarray:
+def read_image(path_or_url: _Path, *, dtype: _DTypeLike = None) -> _NDArray:
   """Returns an image read from a file path or URL.
 
   Decoding is performed using `PIL`, which supports `uint8` images with 1, 3,
@@ -681,7 +695,7 @@ def read_image(path_or_url: _Path, *, dtype: Any = None) -> np.ndarray:
   return decompress_image(data, dtype)
 
 
-def write_image(path: _Path, image: np.ndarray, **kwargs: Any) -> None:
+def write_image(path: _Path, image: _ArrayLike, **kwargs: Any) -> None:
   """Writes an image to a file.
 
   Encoding is performed using `PIL`, which supports `uint8` images with 1, 3,
@@ -702,12 +716,12 @@ def write_image(path: _Path, image: np.ndarray, **kwargs: Any) -> None:
 
 
 def to_rgb(
-    array: Any,
+    array: _ArrayLike,
     *,
     vmin: Optional[float] = None,
     vmax: Optional[float] = None,
-    cmap: Union[str, Callable[[np.ndarray], np.ndarray]] = 'gray',
-) -> np.ndarray:
+    cmap: Union[str, Callable[[_ArrayLike], _NDArray]] = 'gray',
+) -> _NDArray:
   """Maps scalar values to RGB using value bounds and a color map.
 
   Args:
@@ -723,27 +737,26 @@ def to_rgb(
     A new array in which each element is affinely mapped from [vmin, vmax]
     to [0.0, 1.0] and then color-mapped.
   """
-  array = _as_valid_media_array(array)
+  a = _as_valid_media_array(array)
+  del array
   # For future numpy version 1.7.0:
-  # vmin = np.min(array, where=np.isfinite(array)) if vmin is None else vmin
-  # vmax = np.max(array, where=np.isfinite(array)) if vmax is None else vmax
-  vmin = np.min(np.where(np.isfinite(array), array,
-                         np.inf)) if vmin is None else vmin
-  vmax = np.max(np.where(np.isfinite(array), array,
-                         -np.inf)) if vmax is None else vmax
-  array = (array - vmin) / (vmax - vmin + np.finfo(float).eps)
+  # vmin = np.amin(a, where=np.isfinite(a)) if vmin is None else vmin
+  # vmax = np.amax(a, where=np.isfinite(a)) if vmax is None else vmax
+  vmin = np.amin(np.where(np.isfinite(a), a, np.inf)) if vmin is None else vmin
+  vmax = np.amax(np.where(np.isfinite(a), a, -np.inf)) if vmax is None else vmax
+  a = (a - vmin) / (vmax - vmin + np.finfo(float).eps)
   if isinstance(cmap, str):
     rgb_from_scalar = plt.cm.get_cmap(cmap)
   else:
     rgb_from_scalar = cmap
-  array = rgb_from_scalar(array)
+  a = rgb_from_scalar(a)
   # If there is a fully opaque alpha channel, remove it.
-  if (array.shape[-1] == 4 and np.all(to_float01(array[..., 3])) == 1.0):
-    array = array[..., :3]
-  return array
+  if (a.shape[-1] == 4 and np.all(to_float01(a[..., 3])) == 1.0):
+    a = a[..., :3]
+  return a
 
 
-def compress_image(image: np.ndarray,
+def compress_image(image: _ArrayLike,
                    *,
                    fmt: str = 'png',
                    **kwargs: Any) -> bytes:
@@ -761,7 +774,7 @@ def compress_image(image: np.ndarray,
     return output.getvalue()
 
 
-def decompress_image(data: bytes, dtype: Any = None) -> np.ndarray:
+def decompress_image(data: bytes, dtype: _DTypeLike = None) -> _NDArray:
   """Returns an image from a compressed data buffer.
 
   Decoding is performed using `PIL`, which supports `uint8` images with 1, 3,
@@ -822,7 +835,7 @@ def _get_width_height(width: Optional[int], height: Optional[int],
   return shape[::-1]
 
 
-def show_image(image: Any,
+def show_image(image: _ArrayLike,
                *,
                title: Optional[str] = None,
                **kwargs: Any) -> None:
@@ -842,10 +855,10 @@ def show_image(image: Any,
     title: Optional text shown centered above the image.
     **kwargs: See `show_images`.
   """
-  show_images([image], [title], **kwargs)
+  show_images([np.asarray(image)], [title], **kwargs)
 
 
-def show_images(images: Union[Iterable[np.ndarray], Mapping[str, np.ndarray]],
+def show_images(images: Union[Iterable[_ArrayLike], Mapping[str, _ArrayLike]],
                 titles: Optional[Iterable[Optional[str]]] = None,
                 *,
                 width: Optional[int] = None,
@@ -854,7 +867,7 @@ def show_images(images: Union[Iterable[np.ndarray], Mapping[str, np.ndarray]],
                 columns: Optional[int] = None,
                 vmin: Optional[float] = None,
                 vmax: Optional[float] = None,
-                cmap: Union[str, Callable[[np.ndarray], np.ndarray]] = 'gray',
+                cmap: Union[str, Callable[[_ArrayLike], _NDArray]] = 'gray',
                 border: Union[bool, str] = False,
                 ylabel: str = '',
                 html_class: str = 'show_images') -> None:
@@ -898,7 +911,7 @@ def show_images(images: Union[Iterable[np.ndarray], Mapping[str, np.ndarray]],
       raise ValueError('Number of images does not match number of titles'
                        f' ({len(list_images)} vs {len(list_titles)}).')
 
-  def ensure_mapped_to_rgb(image: Any) -> np.ndarray:
+  def ensure_mapped_to_rgb(image: _ArrayLike) -> _NDArray:
     image = _as_valid_media_array(image)
     if not (image.ndim == 2 or
             (image.ndim == 3 and image.shape[2] in (1, 3, 4))):
@@ -912,9 +925,10 @@ def show_images(images: Union[Iterable[np.ndarray], Mapping[str, np.ndarray]],
 
   list_images = [ensure_mapped_to_rgb(image) for image in list_images]
 
-  def maybe_downsample(image: np.ndarray) -> np.ndarray:
-    w, h = _get_width_height(width, height, image.shape[:2])
-    if w < image.shape[1] or h < image.shape[0]:
+  def maybe_downsample(image: _NDArray) -> _NDArray:
+    shape = typing.cast(Tuple[int, int], image.shape[:2])
+    w, h = _get_width_height(width, height, shape)
+    if w < shape[1] or h < shape[0]:
       image = resize_image(image, (h, w))
     return image
 
@@ -955,7 +969,7 @@ def show_images(images: Union[Iterable[np.ndarray], Mapping[str, np.ndarray]],
   IPython.display.display(IPython.display.HTML(s))
 
 
-## Video I/O.
+# ** Video I/O.
 
 
 def _filename_suffix_from_codec(codec: str) -> str:
@@ -1042,7 +1056,7 @@ def _get_video_metadata(path: _Path) -> VideoMetadata:
 class _VideoIO:
   """Base class for `VideoReader` and `VideoWriter`."""
 
-  def _get_pix_fmt(self, dtype: Any, image_format: str) -> str:
+  def _get_pix_fmt(self, dtype: _DType, image_format: str) -> str:
     """Returns ffmpeg pix_fmt given data type and image format."""
     native_endian_suffix = {'little': 'le', 'big': 'be'}[sys.byteorder]
     return {
@@ -1096,7 +1110,7 @@ class VideoReader(_VideoIO, ContextManager[Any]):
   """
   path_or_url: _Path
   output_format: str
-  dtype: Any
+  dtype: _DType
   metadata: VideoMetadata
   num_images: int
   shape: Tuple[int, int]
@@ -1108,14 +1122,14 @@ class VideoReader(_VideoIO, ContextManager[Any]):
                path_or_url: _Path,
                *,
                output_format: str = 'rgb',
-               dtype: Any = np.uint8):
+               dtype: _DTypeLike = np.uint8):
     if output_format not in {'rgb', 'yuv', 'gray'}:
       raise ValueError(
           f'Output format {output_format} is not rgb, yuv, or gray.')
     self.path_or_url = path_or_url
     self.output_format = output_format
     self.dtype = np.dtype(dtype)
-    if self.dtype not in (np.uint8, np.uint16):
+    if self.dtype.type not in (np.uint8, np.uint16):
       raise ValueError(f'Type {dtype} is not np.uint8 or np.uint16.')
     self._read_via_local_file: Any = None
     self._popen: Optional['subprocess.Popen[bytes]'] = None
@@ -1125,6 +1139,7 @@ class VideoReader(_VideoIO, ContextManager[Any]):
     ffmpeg_path = _get_ffmpeg_path()
     try:
       self._read_via_local_file = _read_via_local_file(self.path_or_url)
+      # pylint: disable-next=no-member
       tmp_name = self._read_via_local_file.__enter__()
 
       self.metadata = _get_video_metadata(tmp_name)
@@ -1151,7 +1166,7 @@ class VideoReader(_VideoIO, ContextManager[Any]):
   def __exit__(self, *_: Any) -> None:
     self.close()
 
-  def read(self) -> Optional[np.ndarray]:
+  def read(self) -> Optional[_NDArray]:
     """Reads a video image frame (or None if at end of file).
 
     Returns:
@@ -1176,7 +1191,7 @@ class VideoReader(_VideoIO, ContextManager[Any]):
       raise AssertionError
     return image
 
-  def __iter__(self) -> Generator[np.ndarray, None, None]:
+  def __iter__(self) -> Iterator[_NDArray]:
     while True:
       image = self.read()
       if image is None:
@@ -1190,6 +1205,7 @@ class VideoReader(_VideoIO, ContextManager[Any]):
       self._popen = None
       self._proc = None
     if self._read_via_local_file:
+      # pylint: disable-next=no-member
       self._read_via_local_file.__exit__(None, None, None)
       self._read_via_local_file = None
 
@@ -1253,7 +1269,7 @@ class VideoWriter(_VideoIO, ContextManager[Any]):
                crf: Optional[float] = None,
                ffmpeg_args: Union[str, Sequence[str]] = '',
                input_format: str = 'rgb',
-               dtype: Any = np.uint8,
+               dtype: _DTypeLike = np.uint8,
                encoded_format: Optional[str] = None) -> None:
     _check_2d_shape(shape)
     if fps is None and metadata:
@@ -1280,7 +1296,7 @@ class VideoWriter(_VideoIO, ContextManager[Any]):
     if input_format not in {'rgb', 'yuv', 'gray'}:
       raise ValueError(f'Input format {input_format} is not rgb, yuv, or gray.')
     dtype = np.dtype(dtype)
-    if dtype not in (np.uint8, np.uint16):
+    if dtype.type not in (np.uint8, np.uint16):
       raise ValueError(f'Type {dtype} is not np.uint8 or np.uint16.')
     self.path = pathlib.Path(path)
     self.shape = shape
@@ -1326,6 +1342,7 @@ class VideoWriter(_VideoIO, ContextManager[Any]):
     input_pix_fmt = self._get_pix_fmt(self.dtype, self.input_format)
     try:
       self._write_via_local_file = _write_via_local_file(self.path)
+      # pylint: disable-next=no-member
       tmp_name = self._write_via_local_file.__enter__()
 
       # Writing to stdout using ('-f', 'mp4', '-') would require
@@ -1348,7 +1365,7 @@ class VideoWriter(_VideoIO, ContextManager[Any]):
   def __exit__(self, *_: Any) -> None:
     self.close()
 
-  def add_image(self, image: np.ndarray) -> None:
+  def add_image(self, image: _NDArray) -> None:
     """Writes a video frame.
 
     Args:
@@ -1400,23 +1417,24 @@ class VideoWriter(_VideoIO, ContextManager[Any]):
       self._popen = None
       self._proc = None
     if self._write_via_local_file:
+      # pylint: disable-next=no-member
       self._write_via_local_file.__exit__(None, None, None)
       self._write_via_local_file = None
 
 
-class _VideoArray(np.ndarray):
+class _VideoArray(npt.NDArray[Any]):
   """Wrapper to add a VideoMetadata `metadata` attribute to a numpy array."""
 
   metadata: Optional[VideoMetadata]
 
   def __new__(cls: Type['_VideoArray'],
-              input_array: np.ndarray,
+              input_array: _NDArray,
               metadata: Optional[VideoMetadata] = None) -> '_VideoArray':
     obj: _VideoArray = np.asarray(input_array).view(cls)
     obj.metadata = metadata
     return obj
 
-  def __array_finalize__(self, obj: '_VideoArray') -> None:
+  def __array_finalize__(self, obj: '_VideoArray') -> None:  # type: ignore
     if obj is None:
       return
     self.metadata = getattr(obj, 'metadata', None)
@@ -1447,7 +1465,7 @@ def read_video(path_or_url: _Path, **kwargs: Any) -> _VideoArray:
     return _VideoArray(np.array(tuple(reader)), metadata=reader.metadata)
 
 
-def write_video(path: _Path, images: Iterable[np.ndarray],
+def write_video(path: _Path, images: Iterable[_NDArray],
                 **kwargs: Any) -> None:
   """Writes images to a compressed video file.
 
@@ -1462,19 +1480,19 @@ def write_video(path: _Path, images: Iterable[np.ndarray],
     **kwargs: Additional parameters for `VideoWriter`.
   """
   first_image, images = _peek_first(images)
-  shape = first_image.shape[:2]
+  shape = typing.cast(Tuple[int, int], first_image.shape[:2])
   dtype = first_image.dtype
-  if dtype == np.bool:
-    dtype = np.uint8
+  if dtype == bool:
+    dtype = np.dtype(np.uint8)
   elif np.issubdtype(dtype, np.floating):
-    dtype = np.uint16
+    dtype = np.dtype(np.uint16)
   kwargs = {'metadata': getattr(images, 'metadata', None), **kwargs}
   with VideoWriter(path, shape=shape, dtype=dtype, **kwargs) as writer:
     for image in images:
       writer.add_image(image)
 
 
-def compress_video(images: Iterable[np.ndarray],
+def compress_video(images: Iterable[_NDArray],
                    *,
                    codec: str = 'h264',
                    **kwargs: Any) -> bytes:
@@ -1504,7 +1522,7 @@ def compress_video(images: Iterable[np.ndarray],
     return tmp_path.read_bytes()
 
 
-def decompress_video(data: bytes, **kwargs: Any) -> np.ndarray:
+def decompress_video(data: bytes, **kwargs: Any) -> _NDArray:
   """Returns video images from an MP4-compressed data buffer."""
   with tempfile.TemporaryDirectory() as directory_name:
     tmp_path = pathlib.Path(directory_name) / 'file.mp4'
@@ -1549,7 +1567,7 @@ def html_from_compressed_video(data: bytes,
   return s
 
 
-def show_video(images: Iterable[np.ndarray],
+def show_video(images: Iterable[_NDArray],
                *,
                title: Optional[str] = None,
                **kwargs: Any) -> None:
@@ -1573,8 +1591,8 @@ def show_video(images: Iterable[np.ndarray],
   show_videos([images], [title], **kwargs)
 
 
-def show_videos(videos: Union[Iterable[Iterable[np.ndarray]],
-                              Mapping[str, Iterable[np.ndarray]]],
+def show_videos(videos: Union[Iterable[Iterable[_NDArray]],
+                              Mapping[str, Iterable[_NDArray]]],
                 titles: Optional[Iterable[Optional[str]]] = None,
                 *,
                 width: Optional[int] = None,
@@ -1625,7 +1643,7 @@ def show_videos(videos: Union[Iterable[Iterable[np.ndarray]],
           'Cannot have both a video dictionary and a titles parameter.')
     list_titles, list_videos = list(videos.keys()), list(videos.values())
   else:
-    list_videos = typing.cast(List[Iterable[np.ndarray]], list(videos))
+    list_videos = typing.cast(List[Iterable[_NDArray]], list(videos))
     list_titles = [None] * len(list_videos) if titles is None else list(titles)
     if len(list_videos) != len(list_titles):
       raise ValueError('Number of videos does not match number of titles'
@@ -1668,3 +1686,7 @@ def show_videos(videos: Union[Iterable[Iterable[np.ndarray]],
                          f' style="border-spacing:0px;"><tr>{s}</tr></table>')
   s = ''.join(table_strings)
   IPython.display.display(IPython.display.HTML(s))
+
+# Local Variables:
+# fill-column: 80
+# End:

--- a/mediapy_test.py
+++ b/mediapy_test.py
@@ -30,8 +30,9 @@ import unittest.mock as mock
 from absl.testing import absltest
 from absl.testing import parameterized
 import IPython
-import mediapy as media
 import numpy as np
+
+import mediapy as media
 
 _TEST_TYPES = ['uint8', 'uint16', 'uint32', 'float32', 'float64']
 _TEST_SHAPES1 = [(13, 21, 3), (14, 38, 2), (16, 21, 1), (18, 20), (17, 19)]
@@ -159,7 +160,7 @@ class MediapyTest(parameterized.TestCase):
     check(f64, np.uint16, [0, int(0.4 * 65535 + 0.5), 65535])
     check(f64, np.uint32, [0, int(0.4 * max32 + 0.5), max32])
     check(f64, np.float32, [0.0, np.float32(0.4), 1.0])
-    check(f64, np.float, [0.0, 0.4, 1.0])
+    check(f64, np.float64, [0.0, 0.4, 1.0])
 
     # An array with data type 'uint64' is possible, but it is awkward to process
     # exactly because it requires more than float64 intermediate precision.
@@ -319,11 +320,14 @@ class MediapyTest(parameterized.TestCase):
 
   def test_read_contents(self):
     data = b'Test data'
-    temp_file = self.create_tempfile(content=data)
-    new_data = media.read_contents(temp_file)
-    self.assertEqual(new_data, data)
-    new_data = media.read_contents(pathlib.Path(temp_file))
-    self.assertEqual(new_data, data)
+    with tempfile.TemporaryDirectory() as directory_name:
+      filename = os.path.join(directory_name, 'file')
+      with open(filename, 'wb') as f:
+        f.write(data)
+      new_data = media.read_contents(filename)
+      self.assertEqual(new_data, data)
+      new_data = media.read_contents(pathlib.Path(filename))
+      self.assertEqual(new_data, data)
 
   def test_read_via_local_file_on_local_file(self):
     with tempfile.TemporaryDirectory() as directory_name:
@@ -355,8 +359,8 @@ class MediapyTest(parameterized.TestCase):
 
   def test_write_image(self):
     image = media.color_ramp(shape=(500, 500), dtype=np.uint8)
-    np.random.seed(1)
-    image += np.random.randint(0, 10, size=image.shape, dtype=np.uint8)
+    image += np.random.default_rng(0).integers(
+        10, size=image.shape, dtype=np.uint8)
 
     def get_num_bytes(**kwargs):
       with tempfile.TemporaryDirectory() as directory_name:
@@ -365,11 +369,14 @@ class MediapyTest(parameterized.TestCase):
         return os.path.getsize(filename)
 
     self.assertAlmostEqual(get_num_bytes(), 383588, delta=300)
-    self.assertAlmostEqual(get_num_bytes(optimize=True), 382909, delta=300)
+    self.assertAlmostEqual(get_num_bytes(optimize=True), 382909, delta=600)
 
   def test_to_rgb(self):
     a = np.array([[-0.2, 0.0, 0.2, 0.8, 1.0, 1.2]])
-    gray_color = lambda x: [x, x, x]
+
+    def gray_color(x):
+      return [x, x, x]
+
     self.assert_all_close(
         media.to_rgb(a), [[
             gray_color(0.0 / 1.4),
@@ -440,8 +447,7 @@ class MediapyTest(parameterized.TestCase):
       self.assertFalse((directory_path / 'ramp4.png').is_file())
 
   def test_show_image_downsampled(self):
-    np.random.seed(1)
-    image = np.random.rand(256, 256, 3)
+    image = np.random.default_rng(0).random((256, 256, 3))
     for downsample in (False, True):
       htmls = []
       with mock.patch('IPython.display.display', htmls.append):
@@ -640,8 +646,7 @@ class MediapyTest(parameterized.TestCase):
         self.assertBetween(path.stat().st_size, 1500, 3000)
 
   def test_show_video_downsampled(self):
-    np.random.seed(1)
-    video = np.random.rand(5, 64, 128, 3)
+    video = np.random.default_rng(0).random((5, 64, 128, 3))
     for downsample in (False, True):
       htmls = []
       with mock.patch('IPython.display.display', htmls.append):
@@ -683,3 +688,7 @@ class MediapyTest(parameterized.TestCase):
 
 if __name__ == '__main__':
   absltest.main()
+
+# Local Variables:
+# fill-column: 80
+# End:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@
 import pathlib
 import setuptools
 
+NAME = 'mediapy'
+
 
 def get_long_description():
   return pathlib.Path('README.md').read_text()
@@ -31,8 +33,8 @@ def get_version(rel_path):
 
 
 setuptools.setup(
-    name='mediapy',
-    version=get_version('mediapy/__init__.py'),
+    name=NAME,
+    version=get_version(f'{NAME}/__init__.py'),
     author='Google LLC',
     author_email='mediapy-owners@google.com',
     description='Read/write/show images and videos in an IPython notebook',
@@ -40,7 +42,10 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/google/mediapy',
     license='Apache-2.0',
-    packages=['mediapy'],
+    packages=[NAME],
+    package_data={
+        NAME: ['py.typed'],
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
- Fix warning about PIL.Image.Resampling:
  (Pillow 9.0 deprecates PIL.Image.LANCZOS; requires PIL.Image.Resampling.LANCZOS)
- Fix warning about "dtype == np.bool"; numpy now desires "dtype == bool".
- Fix warnings about use of np.ndarray without subscripting (rather than np.ndarray[Any, Any]).
- Add py.typed to let mypy know this package has type annotations.
- Improve typing of parameters and return values, using numpy types.
- Check code using flake8, mypy, autopep8, and pylint, and tweak code accordingly.
- Replace deprecated np.max() by np.amax().
- Replace random.seed in tests using the more recent numpy random generators.
- In mediapy_test, correct an np.float which should have been np.float64.