### PR TITLE
Remove warnings and fix types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 /dist/
 /*.egg-info/
 /*.egg
+.ipynb_checkpoints/

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@
 import pathlib
 import setuptools
 
+NAME = 'mediapy'
+
 
 def get_long_description():
   return pathlib.Path('README.md').read_text()
@@ -31,8 +33,8 @@ def get_version(rel_path):
 
 
 setuptools.setup(
-    name='mediapy',
-    version=get_version('mediapy/__init__.py'),
+    name=NAME,
+    version=get_version(f'{NAME}/__init__.py'),
     author='Google LLC',
     author_email='mediapy-owners@google.com',
     description='Read/write/show images and videos in an IPython notebook',
@@ -40,7 +42,10 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/google/mediapy',
     license='Apache-2.0',
-    packages=['mediapy'],
+    packages=[NAME],
+    package_data={
+        NAME: ['py.typed'],
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
- Fix warning about PIL.Image.Resampling:
  (Pillow 9.0 deprecates PIL.Image.LANCZOS; requires PIL.Image.Resampling.LANCZOS)
- Fix warning about "dtype == np.bool"; numpy now desires "dtype == bool".
- Fix warnings about use of np.ndarray without subscripting (rather than np.ndarray[Any, Any]).
- Add py.typed to let mypy know this package has type annotations.
- Improve typing of parameters and return values, using numpy types.
- Check code using flake8, mypy, autopep8, and pylint, and tweak code accordingly.
- Replace deprecated np.max() by np.amax().
- Replace random.seed in tests using the more recent numpy random generators.
- In mediapy_test, correct an np.float which should have been np.float64.

Also merged with existing changes.