### PR TITLE
Fix issue 9 (to_rgb on uint8)

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -746,7 +746,7 @@ def to_rgb(
   # vmax = np.amax(a, where=np.isfinite(a)) if vmax is None else vmax
   vmin = np.amin(np.where(np.isfinite(a), a, np.inf)) if vmin is None else vmin
   vmax = np.amax(np.where(np.isfinite(a), a, -np.inf)) if vmax is None else vmax
-  a = (a - vmin) / (vmax - vmin + np.finfo(float).eps)
+  a = (a.astype('float') - vmin) / (vmax - vmin + np.finfo(float).eps)
   if isinstance(cmap, str):
     rgb_from_scalar = plt.cm.get_cmap(cmap)
   else:

--- a/mediapy_test.py
+++ b/mediapy_test.py
@@ -29,6 +29,7 @@ import unittest.mock as mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
+import matplotlib.pyplot as plt
 import IPython
 import mediapy as media
 import numpy as np
@@ -387,6 +388,21 @@ class MediapyTest(parameterized.TestCase):
         media.to_rgb(a, vmin=-1.0, vmax=1.0, cmap='bwr'),
         [[0.596078, 0.596078, 1.0], [1.0, 0.996078, 0.996078], [1.0, 0.8, 0.8]],
         atol=0.002)
+
+  def test_uint8_to_rgb(self):
+    a = np.array([100, 120, 140], dtype=np.uint8)
+
+    def gray(x):
+      return plt.cm.get_cmap('gray')(x)[..., :3]
+
+    self.assert_all_close(media.to_rgb(a), gray([0.0, 0.5, 1.0]))
+    self.assert_all_close(
+        media.to_rgb(a, vmin=80, vmax=160), gray([0.25, 0.5, 0.75]))
+    self.assert_all_close(
+        media.to_rgb(a, vmin=110, vmax=160), gray([0.0, 0.2, 0.6]))
+    self.assert_all_close(
+        media.to_rgb(a, vmin=110, vmax=130), gray([0.0, 0.5, 1.0]))
+
 
   @parameterized.parameters('uint8', 'uint16')
   def test_compress_decompress_image_roundtrip(self, dtype):


### PR DESCRIPTION
Fix #9 .
Adding `np.clip(a, 0.0, 1.0)` seems unnecessary because the color map function handles this already.