### PR TITLE
Run pytest on python 3.7 and 3.x

### DIFF
--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -12,15 +12,20 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
 
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.x']
+
     steps:
     - uses: actions/checkout@v3
 
     - run: sudo apt-get install ffmpeg
 
     # Install deps
-    - uses: actions/setup-python@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - run: pip --version
     - run: pip install -e .[dev]
     - run: pip freeze

--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -3,14 +3,14 @@ name: Unittests & Auto-publish
 # Allow to trigger the workflow manually (e.g. when deps changes)
 on: [push, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest-job:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
 
     strategy:
       matrix:


### PR DESCRIPTION
(It was necessary to move "concurrency" in the outer scope; otherwise, the jobs in the matrix would cancel each other.)