### PR TITLE
Setup ffmpeg in github workflow.

### DIFF
--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up ffmpeg
-    - uses: FedericoCarboni/setup-ffmpeg@v2
+      uses: FedericoCarboni/setup-ffmpeg@v2
       id: setup-ffmpeg
 
     # Install deps

--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: sudo apt update
-    - run: sudo apt install -y ffmpeg
+    - run: sudo apt-get update
+    - run: sudo apt-get install -y ffmpeg
 
     # Install deps
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: sudo apt-get install ffmpeg
+    - name: Set up ffmpeg
+    - uses: FedericoCarboni/setup-ffmpeg@v2
+      id: setup-ffmpeg
 
     # Install deps
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -21,9 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v2
-      id: setup-ffmpeg
+    - run: sudo apt update
+    - run: sudo apt install -y ffmpeg
 
     # Install deps
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This fixes the github workflow failure.
The previous command "apt-get install ffmpeg" seems to no longer work.
This relies on a third-party action defined in:
  https://github.com/marketplace/actions/setup-ffmpeg
  https://github.com/FedericoCarboni/setup-ffmpeg

