### PR TITLE
Add "muted" attribute to <video>

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -1856,5 +1856,5 @@ def show_videos(
 
 
 # Local Variables:
-# fill-column: 88
+# fill-column: 80
 # End:

--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -99,7 +99,7 @@ Darken a video frame-by-frame:
 from __future__ import annotations
 
 __docformat__ = 'google'
-__version__ = '1.1.4'
+__version__ = '1.1.5'
 __version_info__ = tuple(int(num) for num in __version__.split('.'))
 
 import base64
@@ -1697,7 +1697,8 @@ def html_from_compressed_video(
   options = (
       f'controls width="{width}" height="{height}"'
       f' style="{border}object-fit:cover;"'
-      f"{' loop' if loop else ''}{' autoplay' if autoplay else ''}"
+      f"{' loop' if loop else ''}"
+      f"{' autoplay muted' if autoplay else ''}"
   )
   s = f"""<video {options}>
       <source src="data:video/mp4;base64,{b64}" type="video/mp4"/>

--- a/mediapy_test.py
+++ b/mediapy_test.py
@@ -801,5 +801,5 @@ if __name__ == '__main__':
 
 
 # Local Variables:
-# fill-column: 88
+# fill-column: 80
 # End:


### PR DESCRIPTION
Web browsers often disable autoplay of HTML video unless the `<video>` tag contains the `muted` attribute.
I am not sure why this has not been a problem so far; maybe the policy is not applied for (small) videos where the source data is provided in-line using ` <source src="data:video/mp4;base64,{b64}" type="video/mp4"/>`.
In our case, the videos do not have sound, so it is safe to always let them start in the `muted` state when `autoplay` is on.
Perhaps this might resolve issue #27.