### PR TITLE
Add media.compare_images()

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -104,7 +104,7 @@ with VideoReader(VIDEO) as r:
 from __future__ import annotations
 
 __docformat__ = 'google'
-__version__ = '1.1.6'
+__version__ = '1.1.8'
 __version_info__ = tuple(int(num) for num in __version__.split('.'))
 
 import base64

--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -1123,8 +1123,8 @@ def compare_images(
   """Compare two images using an interactive slider.
 
   Displays an HTML slider component to interactively swipe between two images.
-  The slider functionality requires Internet access.  See additional info in
-  `https://github.com/sneas/img-comparison-slider`.
+  The slider functionality requires that the web browser have Internet access.
+  See additional info in `https://github.com/sneas/img-comparison-slider`.
 
   >>> image1, image2 = np.random.rand(64, 64, 3), color_ramp((64, 64))
   >>> compare_images([image1, image2])

--- a/mediapy_test.py
+++ b/mediapy_test.py
@@ -15,7 +15,6 @@
 """Tests for package mediapy."""
 
 import io
-import os
 import pathlib
 import re
 import tempfile

--- a/mediapy_test.py
+++ b/mediapy_test.py
@@ -553,6 +553,16 @@ class MediapyTest(parameterized.TestCase):
     self.assertLen(re.findall('(?s)<table', htmls[0].data), 3)
     self.assertLen(re.findall('(?s)<img', htmls[0].data), 5)
 
+  def test_compare_images(self):
+    htmls = []
+    with mock.patch('IPython.display.display', htmls.append):
+      media.compare_images([media.color_ramp()] * 2)
+    self.assertLen(htmls, 1)
+    self.assertIsInstance(htmls[0], IPython.display.HTML)
+    self.assertLen(re.findall('(?s)<img-comparison-slider>', htmls[0].data), 1)
+    self.assertLen(re.findall('(?s)base64', htmls[0].data), 2)
+    self.assertLen(re.findall('(?s)b64', htmls[0].data), 0)
+
   @parameterized.parameters(False, True)
   def test_video_non_streaming_write_read_roundtrip(self, use_generator):
     shape = (240, 320)


### PR DESCRIPTION
Addresses issue #33 .

```
Compare two images using an interactive slider.
  Displays an HTML slider component to interactively swipe between two images.
  The slider functionality requires that the web browser have Internet access.
  See additional info in `https://github.com/sneas/img-comparison-slider`.
  >>> image1, image2 = np.random.rand(64, 64, 3), color_ramp((64, 64))
  >>> compare_images([image1, image2])
```