### PR TITLE
Make _get_video_metadata() ignore the metadata reported by ffmpeg on its video output stream.

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -104,7 +104,7 @@ with VideoReader(VIDEO) as r:
 from __future__ import annotations
 
 __docformat__ = 'google'
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 __version_info__ = tuple(int(num) for num in __version__.split('.'))
 
 import base64
@@ -1228,12 +1228,15 @@ def _get_video_metadata(path: _Path) -> VideoMetadata:
   ) as proc:
     _, err = proc.communicate()
   bps = fps = num_images = width = height = rotation = None
+  before_output_info = True
   for line in err.split('\n'):
+    if line.startswith('Output '):
+      before_output_info = False
     if match := re.search(r', bitrate: *([\d.]+) kb/s', line):
       bps = int(match.group(1)) * 1000
     if matches := re.findall(r'frame= *(\d+) ', line):
       num_images = int(matches[-1])
-    if 'Stream #0:' in line and ': Video:' in line:
+    if 'Stream #0:' in line and ': Video:' in line and before_output_info:
       if not (match := re.search(r', (\d+)x(\d+)', line)):
         raise RuntimeError(f'Unable to parse video dimensions in line {line}')
       width, height = int(match.group(1)), int(match.group(2))

--- a/mediapy_examples.ipynb
+++ b/mediapy_examples.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20301766",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,5 +1258,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/mediapy_examples.py
+++ b/mediapy_examples.py
@@ -1,3 +1,4 @@
+# %%
 # Copyright 2024 The mediapy Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# %%
 # %% [markdown]
 # <!--
 # pylint: disable=line-too-long


### PR DESCRIPTION
This fixes the issue discussed in #52 whereby the dimensions of a rotated video were not parsed correctly.
We parse the metadata for ffmpeg's video input stream, and not its video output stream.