### PR TITLE
Update _VideoArray base class to np.ndarray rather than npt.NDArray

### DIFF
--- a/mediapy/__init__.py
+++ b/mediapy/__init__.py
@@ -1812,7 +1812,7 @@ class VideoWriter(_VideoIO):
       self._write_via_local_file = None
 
 
-class _VideoArray(npt.NDArray[Any]):
+class _VideoArray(np.ndarray):
   """Wrapper to add a VideoMetadata `metadata` attribute to a numpy array."""
 
   metadata: VideoMetadata | None


### PR DESCRIPTION
npt.NDArray as a base class seems to cause issues with numpy 2.5 and prevents importing of mediapy. 

For instance, when I `import mediapy` with numpy 2.5 installed in my environment, I get
```
Traceback (most recent call last):
  File "mediapy/test.py", line 1, in <module>
    import mediapy
  File "mediapy/mediapy/__init__.py", line 1815, in <module>
    class _VideoArray(npt.NDArray[Any]):
TypeError: typealias() takes exactly 2 positional arguments (3 given)
```

Switching the base class to a standard array (rather than a type hint) fixes this problem. All test cases in `mediapy_test` still pass!