### PR TITLE
fix(security): pin GitHub Actions to commit SHAs in publish workflow

### DIFF
--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -19,14 +19,14 @@ jobs:
         python-version: ['3.10', '3.x']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - run: sudo apt-get update
     - run: sudo apt-get install -y ffmpeg
 
     # Install deps
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip --version
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `pytest_and_autopublish.yml` workflow uses mutable tag references for all three of its actions, including **`etils-actions/pypi-auto-publish@v1`** — a third-party action with minimal vetting (~10 GitHub stars). If any tag is silently redirected, the malicious code runs in the job that holds **`PYPI_API_TOKEN`**, enabling a backdoored release of `mediapy` on PyPI.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e11487…` |
| `actions/setup-python` | `@v5` | `@a26af69b…` |
| `etils-actions/pypi-auto-publish` | `@v1` | `@e3c4b4af…` |

SHA-pinning is recommended by the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).